### PR TITLE
Update CNAME to association.drupalcampmontreal.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-drupalcampmontreal.com
+association.drupalcampmontreal.com


### PR DESCRIPTION
At the moment only *.drupalcampmontreal.com redirects Acquia cloud, while association.drupalcampmontreal.com CNAME drupalmontreal.github.io (Github Pages).

This pull request will make the site visible.
